### PR TITLE
fixed dev pipeline trigger (success is not supported for workflow_run)

### DIFF
--- a/.github/workflows/continuous_delivery_dev.yml
+++ b/.github/workflows/continuous_delivery_dev.yml
@@ -4,12 +4,12 @@ on:
   workflow_run:
     workflows: ["CI Pipeline"]
     types:
-      - success
+      - completed
 
 jobs:
-  
+
   setup-env-job:
-    if: ${{ github.repository != 'Azure/llmops-project-template' }}        
+    if: ${{ github.repository != 'Azure/llmops-project-template' && github.event.workflow_run.conclusion == 'success' }}        
     runs-on: ubuntu-latest
     environment: dev
     outputs:
@@ -60,7 +60,7 @@ jobs:
           AZURE_STORAGE_ACCOUNT_NAME: ${{ vars.AZURE_STORAGE_ACCOUNT_NAME }}
 
   deploy-flow:
-    if: ${{ github.repository != 'Azure/llmops-project-template' }}    
+    if: ${{ github.repository != 'Azure/llmops-project-template' && github.event.workflow_run.conclusion == 'success' }}   
     runs-on: ubuntu-latest
     needs: [setup-env-job] 
     environment: dev


### PR DESCRIPTION
workflow_run trigger does not support success - see [docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run)